### PR TITLE
Возможность настройки ответов реплаями

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -109,6 +109,32 @@ func (commandRequest *commandGentle) Handle() error {
 	return nil
 }
 
+type commandReply botCommand
+
+func (commandRequest *commandReply) Handle() error {
+	settings.cache[commandRequest.request.cacheID].Reply = true
+	if err := settings.SaveCache(commandRequest.request.ctx, commandRequest.request.cacheID); err != nil {
+		commandRequest.request.logWarn(err)
+		// Do not send error to command
+		return nil
+	}
+	commandRequest.request.answer("Режим ответов на сообщения *включен*\nЧтобы отключить его, используйте команду /noreply", MarkdownV2)
+	return nil
+}
+
+type commandNoReply botCommand
+
+func (commandRequest *commandNoReply) Handle() error {
+	settings.cache[commandRequest.request.cacheID].Reply = false
+	if err := settings.SaveCache(commandRequest.request.ctx, commandRequest.request.cacheID); err != nil {
+		commandRequest.request.logWarn(err)
+		// Do not send error to command
+		return nil
+	}
+	commandRequest.request.answer("Режим ответов на сообщения *отключен*\nЧтобы включить его, используйте команду /reply", MarkdownV2)
+	return nil
+}
+
 type commandAmount botCommand
 
 func (commandRequest *commandAmount) Handle() error {

--- a/settings.go
+++ b/settings.go
@@ -12,6 +12,7 @@ type ChatSettings struct {
 	Enabled     bool
 	Gentle      bool
 	WordsAmount int
+	Reply       bool
 }
 
 type Settings struct {
@@ -60,6 +61,7 @@ func (s Settings) DefaultChatSettings() ChatSettings {
 		Enabled:     true,
 		Gentle:      true,
 		WordsAmount: 1,
+		Reply:       false,
 	}
 }
 

--- a/xyebot.go
+++ b/xyebot.go
@@ -40,17 +40,15 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	request.handleDelay()
-	replyID := request.getReplyIDIfNeeded()
-	if request.isAnswerNeeded(replyID) {
-		if replyID == nil {
-			request.cleanDelay()
-		}
-		output := request.huify()
-		if output != "" {
-			sendMessage(request.writer, request.updateMessage.Chat.ID, output, replyID, "")
-			return
-		}
+	if !request.isAnswerNeeded() {
+		return
 	}
+	output := request.huify()
+	if output == "" {
+		return
+	}
+	request.cleanDelay()
+	sendMessage(request.writer, request.updateMessage.Chat.ID, output, request.getReplyIDIfNeeded(), "")
 }
 
 func main() {


### PR DESCRIPTION
fix #32 

PR добавляет две команды:
* /reply - чтобы включить режим реплаев
* /noreply - чтобы выключить режим реплаев

Так же, сохраняет текущий режим в Datastore