### PR TITLE
Update Go to 1.16 and runtime to go116

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.15
+    - name: Set up Go 1.16
       uses: actions/setup-go@v1
       with:
-        go-version: 1.15
+        go-version: 1.16
       id: go
 
     - name: Check out code into the Go module directory

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-runtime: go115
+runtime: go116
 handlers:
 - url: /.*
   script: auto

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/m-messiah/xye-bot
 
-go 1.13
+go 1.16
 
 require cloud.google.com/go/datastore v1.6.0


### PR DESCRIPTION
Google Apps finally supports Go 1.16 - need to upgrade the app to use it