### PR TITLE
Replace ioutil with io

### DIFF
--- a/request.go
+++ b/request.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -12,7 +12,7 @@ import (
 )
 
 func newRequest(w http.ResponseWriter, r *http.Request) (*requestInfo, error) {
-	bytes, _ := ioutil.ReadAll(r.Body)
+	bytes, _ := io.ReadAll(r.Body)
 	var update Update
 	err := json.Unmarshal(bytes, &update)
 	if err != nil {


### PR DESCRIPTION
#40 broke golangci-lint in main:

```
SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
```

The PR replaces `ioutil` with `io` usage.